### PR TITLE
Fix Nginx log path

### DIFF
--- a/docker/copy/etc/nginx/nginx.conf.template
+++ b/docker/copy/etc/nginx/nginx.conf.template
@@ -1,4 +1,4 @@
-error_log /dev/error_log error;
+error_log /var/log/nginx/error.log error;
 
 worker_processes 4;
 


### PR DESCRIPTION
I think this was just a typo that was just working fine - because in docker, everything runs as root.

Logfiles shouldn't be in `/dev`, though. As under OpenShift, the containers user id is choosen randomly. Therefore, you don't have write access to `/dev`. But for `/var/log/nginx`, I can fix this with group permissions.

Please feel free to comment if you have any concerns regarding this change.