### PR TITLE
Feature/nginx unprivileged

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN apk --no-cache add curl
 RUN chown -R 1001 /app/public
 RUN chown 1001 /etc/nginx/nginx.conf
 
-# Now that we are doine with the image build, we switch back to user 1001
+# Now that we are done with the image build, we switch back to user 1001
 USER 1001
 
 # Add health check

--- a/docker/files/etc/nginx/nginx.conf.template
+++ b/docker/files/etc/nginx/nginx.conf.template
@@ -1,4 +1,5 @@
 error_log /var/log/nginx/error.log error;
+pid       /var/cache/nginx/nginx.pid;
 
 worker_processes 4;
 


### PR DESCRIPTION
This PR deals with the issue discussed in https://github.com/elkozmon/zoonavigator/issues/35 where nginx can't start because the container doesn't have privilege. This PR changes how nginx runs to no longer require privilege.

This PR forces users to use a container port above 1024, however the default is 8000 so it should not be an issue for new users. Users who have already deployed zoonavigator-web on port 80 will no longer be able to use that port.