### PR TITLE
Add Missing OS Deps for Chrome Tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,6 +8,9 @@ COPY . .
 RUN npm install -g @angular/cli \
   && npm install
 
+RUN apt-get update \
+  && apt-get install -y wget gnupg2 procps
+
 # Install Chrome
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list \


### PR DESCRIPTION
Hey @elkozmon !

A quick fix for the zoonavigator-web build. A few of the required packages were removed from the node base image which is why tests were failing in the CI.

I've added the missing deps and everything runs properly now.

Could you also take a look at [my other PR on zoonavigator-api ](https://github.com/elkozmon/zoonavigator-api/pull/7)which is fixing the build problem for that component.

Let me know if there's something wrong!